### PR TITLE
Latest CppUTest 3.7.2 compatibility issue resolved.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories($ENV{CPPUTEST_HOME}/include)
 # add cpputest library
 add_library(imp_cpputest STATIC IMPORTED)
 set_property(TARGET imp_cpputest PROPERTY
-             IMPORTED_LOCATION $ENV{CPPUTEST_HOME}/lib/libCppUTest.a)
+             IMPORTED_LOCATION $ENV{CPPUTEST_HOME}/src/CppUTest/libCppUTest.a)
 
 # build test library for LedDriver
 add_library(LedDriverTest ./LedDriver/LedDriverTest.cpp)


### PR DESCRIPTION
Hey Davis,

The recent CppUTest build has changed the location of the compiled `libCppUTest.a` file, so the final  target failed to build.

```
...
[ 90%] Building CXX object tests/CMakeFiles/RunAllTests.dir/RunAllTests.cpp.o
make[2]: *** No rule to make target '/home/vagrant/cpputest/src/libCppUTest.a', needed by 'bin/RunAllTests'.  Stop.
CMakeFiles/Makefile2:275: recipe for target 'tests/CMakeFiles/RunAllTests.dir/all' failed
make[1]: *** [tests/CMakeFiles/RunAllTests.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2
```

Path corrected, project is happy again :)